### PR TITLE
Remove annoying log at infinity-wagon.lua:85

### DIFF
--- a/scripts/infinity-wagon.lua
+++ b/scripts/infinity-wagon.lua
@@ -82,7 +82,6 @@ end
 
 --- @param e DestroyedEvent
 local function on_entity_destroyed(e)
-  log("destroyed: " .. e.entity.name)
   local entity = e.entity
   if not entity or not entity.valid or not wagon_names[entity.name] then
     return


### PR DESCRIPTION
Logs were polluted by numerous instances of:

    Script @__EditorExtensions__/scripts/infinity-wagon.lua:85: destroyed: ...

And I take this opportunity to thank you a lot for writing and maintaining this extension; I use it all the time!