### PR TITLE
fix: support space platform built and mine entity

### DIFF
--- a/scripts/aggregate-chest.lua
+++ b/scripts/aggregate-chest.lua
@@ -10,10 +10,10 @@ do
   local i = 0
   for name, prototype in pairs(prototypes.item) do
     if
-      (include_hidden or not prototype.hidden)
-      -- FIXME: Prevent items from spoiling
-      and not prototype.spoil_result
-      and not prototype.spoil_to_trigger_result
+        (include_hidden or not prototype.hidden)
+        -- FIXME: Prevent items from spoiling
+        and not prototype.spoil_result
+        and not prototype.spoil_to_trigger_result
     then
       i = i + 1
       filters[i] = { name = name, count = prototype.stack_size, mode = "exactly", index = i }
@@ -80,6 +80,7 @@ aggregate_chest.events = {
   [defines.events.on_entity_cloned] = on_entity_built,
   [defines.events.on_player_setup_blueprint] = on_player_setup_blueprint,
   [defines.events.on_robot_built_entity] = on_entity_built,
+  [defines.events.on_space_platform_built_entity] = on_entity_built,
   [defines.events.script_raised_built] = on_entity_built,
   [defines.events.script_raised_revive] = on_entity_built,
 }

--- a/scripts/aggregate-chest.lua
+++ b/scripts/aggregate-chest.lua
@@ -10,10 +10,10 @@ do
   local i = 0
   for name, prototype in pairs(prototypes.item) do
     if
-        (include_hidden or not prototype.hidden)
-        -- FIXME: Prevent items from spoiling
-        and not prototype.spoil_result
-        and not prototype.spoil_to_trigger_result
+      (include_hidden or not prototype.hidden)
+      -- FIXME: Prevent items from spoiling
+      and not prototype.spoil_result
+      and not prototype.spoil_to_trigger_result
     then
       i = i + 1
       filters[i] = { name = name, count = prototype.stack_size, mode = "exactly", index = i }

--- a/scripts/infinity-accumulator.lua
+++ b/scripts/infinity-accumulator.lua
@@ -104,8 +104,8 @@ local function get_slider_values(buffer_size, mode)
   -- `power` is the dropdown value - how many sets of three orders of magnitude there are, rounded down
   local power = math.floor((len - 1) / 3)
   -- Slider value is the buffer size scaled to its base-three order of magnitude
-  return buffer_size / 10 ^ (power * 3) --[[@as uint]],
-      math.max(power, 1) --[[@as uint]]
+  return buffer_size / 10 ^ (power * 3), --[[@as uint]]
+    math.max(power, 1) --[[@as uint]]
 end
 
 --- Returns the entity buffer size based on the power_slider value and dropdown selected index

--- a/scripts/infinity-accumulator.lua
+++ b/scripts/infinity-accumulator.lua
@@ -105,7 +105,7 @@ local function get_slider_values(buffer_size, mode)
   local power = math.floor((len - 1) / 3)
   -- Slider value is the buffer size scaled to its base-three order of magnitude
   return buffer_size / 10 ^ (power * 3) --[[@as uint]],
-    math.max(power, 1) --[[@as uint]]
+      math.max(power, 1) --[[@as uint]]
 end
 
 --- Returns the entity buffer size based on the power_slider value and dropdown selected index
@@ -474,6 +474,7 @@ infinity_accumulator.events = {
   [defines.events.on_player_mined_entity] = on_entity_destroyed,
   [defines.events.on_robot_mined_entity] = on_entity_destroyed,
   [defines.events.script_raised_destroy] = on_entity_destroyed,
+  [defines.events.on_space_platform_mined_entity] = on_entity_destroyed,
 }
 
 return infinity_accumulator

--- a/scripts/infinity-loader.lua
+++ b/scripts/infinity-loader.lua
@@ -19,10 +19,10 @@ local function snap(entity)
   end
   local belt_position = position.add(entity.position, flib_direction.to_vector(offset_direction))
   local belt =
-    entity.surface.find_entities_filtered({ position = belt_position, type = transport_belt_connectables })[1]
+      entity.surface.find_entities_filtered({ position = belt_position, type = transport_belt_connectables })[1]
   if not belt then
     belt =
-      entity.surface.find_entities_filtered({ position = belt_position, ghost_type = transport_belt_connectables })[1]
+        entity.surface.find_entities_filtered({ position = belt_position, ghost_type = transport_belt_connectables })[1]
   end
   if not belt then
     return
@@ -171,7 +171,7 @@ local function on_entity_settings_pasted(e)
     return
   end
   local source_is_loader, destination_is_loader =
-    source.name == "ee-infinity-loader", destination.name == "ee-infinity-loader"
+      source.name == "ee-infinity-loader", destination.name == "ee-infinity-loader"
   if source_is_loader and destination.name == "constant-combinator" then
     copy_from_loader_to_combinator(source, destination)
   elseif source.name == "constant-combinator" and destination_is_loader then
@@ -228,6 +228,8 @@ infinity_loader.events = {
   [defines.events.script_raised_built] = on_entity_built,
   [defines.events.script_raised_destroy] = on_entity_destroyed,
   [defines.events.script_raised_revive] = on_entity_built,
+  [defines.events.on_space_platform_built_entity] = on_entity_built,
+  [defines.events.on_space_platform_mined_entity] = on_entity_destroyed,
 }
 
 infinity_loader.on_nth_tick = {

--- a/scripts/infinity-loader.lua
+++ b/scripts/infinity-loader.lua
@@ -19,10 +19,10 @@ local function snap(entity)
   end
   local belt_position = position.add(entity.position, flib_direction.to_vector(offset_direction))
   local belt =
-      entity.surface.find_entities_filtered({ position = belt_position, type = transport_belt_connectables })[1]
+    entity.surface.find_entities_filtered({ position = belt_position, type = transport_belt_connectables })[1]
   if not belt then
     belt =
-        entity.surface.find_entities_filtered({ position = belt_position, ghost_type = transport_belt_connectables })[1]
+      entity.surface.find_entities_filtered({ position = belt_position, ghost_type = transport_belt_connectables })[1]
   end
   if not belt then
     return
@@ -171,7 +171,7 @@ local function on_entity_settings_pasted(e)
     return
   end
   local source_is_loader, destination_is_loader =
-      source.name == "ee-infinity-loader", destination.name == "ee-infinity-loader"
+    source.name == "ee-infinity-loader", destination.name == "ee-infinity-loader"
   if source_is_loader and destination.name == "constant-combinator" then
     copy_from_loader_to_combinator(source, destination)
   elseif source.name == "constant-combinator" and destination_is_loader then

--- a/scripts/infinity-wagon.lua
+++ b/scripts/infinity-wagon.lua
@@ -148,7 +148,7 @@ local function sync_fluid(data)
           amount = (abs(fluid.amount) / 250),
           temperature = fluid.temperature,
         }
-        or nil
+      or nil
     data.flip = 0
   end
 end

--- a/scripts/infinity-wagon.lua
+++ b/scripts/infinity-wagon.lua
@@ -148,7 +148,7 @@ local function sync_fluid(data)
           amount = (abs(fluid.amount) / 250),
           temperature = fluid.temperature,
         }
-      or nil
+        or nil
     data.flip = 0
   end
 end
@@ -283,6 +283,8 @@ infinity_wagon.events = {
   [defines.events.script_raised_built] = on_entity_built,
   [defines.events.script_raised_destroy] = on_entity_destroyed,
   [defines.events.script_raised_revive] = on_entity_built,
+  [defines.events.on_space_platform_built_entity] = on_entity_built,
+  [defines.events.on_space_platform_mined_entity] = on_entity_destroyed,
   ["ee-linked-open-gui"] = on_linked_open_gui,
 }
 

--- a/scripts/super-pump.lua
+++ b/scripts/super-pump.lua
@@ -266,6 +266,7 @@ super_pump.events = {
   [defines.events.on_robot_built_entity] = on_entity_built,
   [defines.events.script_raised_built] = on_entity_built,
   [defines.events.script_raised_revive] = on_entity_built,
+  [defines.events.on_space_platform_built_entity] = on_entity_built,
 }
 
 return super_pump

--- a/scripts/update-notification.lua
+++ b/scripts/update-notification.lua
@@ -1,5 +1,5 @@
 local content =
-  [[Editor Extensions has been updated to 2.0. This version is a BREAKING CHANGE, meaning that your testing setups may not function as they did before.
+[[Editor Extensions has been updated to 2.0. This version is a BREAKING CHANGE, meaning that your testing setups may not function as they did before.
 
 The infinity loader has been overhauled to fix belt saturation issues, solve edge cases with blueprints, and make them much more UPS efficient. Due to this, [font=default-bold][color=255,50,50]all previously placed infinity loaders will no longer function.[/color][/font] You will need to replace them in order for your testing setups to work again.
 
@@ -106,9 +106,9 @@ local update_notification = {}
 update_notification.on_configuration_changed = function(e)
   local ee_changes = e.mod_changes["EditorExtensions"]
   if
-    not ee_changes
-    or not ee_changes.old_version
-    or flib_migration.is_newer_version("1.99.99", ee_changes.old_version)
+      not ee_changes
+      or not ee_changes.old_version
+      or flib_migration.is_newer_version("1.99.99", ee_changes.old_version)
   then
     return
   end
@@ -170,6 +170,7 @@ update_notification.events = {
   [defines.events.on_robot_built_entity] = on_entity_built,
   [defines.events.script_raised_built] = on_entity_built,
   [defines.events.script_raised_revive] = on_entity_built,
+  [defines.events.on_space_platform_built_entity] = on_entity_built,
 }
 
 return update_notification

--- a/scripts/update-notification.lua
+++ b/scripts/update-notification.lua
@@ -1,5 +1,5 @@
 local content =
-[[Editor Extensions has been updated to 2.0. This version is a BREAKING CHANGE, meaning that your testing setups may not function as they did before.
+  [[Editor Extensions has been updated to 2.0. This version is a BREAKING CHANGE, meaning that your testing setups may not function as they did before.
 
 The infinity loader has been overhauled to fix belt saturation issues, solve edge cases with blueprints, and make them much more UPS efficient. Due to this, [font=default-bold][color=255,50,50]all previously placed infinity loaders will no longer function.[/color][/font] You will need to replace them in order for your testing setups to work again.
 
@@ -106,9 +106,9 @@ local update_notification = {}
 update_notification.on_configuration_changed = function(e)
   local ee_changes = e.mod_changes["EditorExtensions"]
   if
-      not ee_changes
-      or not ee_changes.old_version
-      or flib_migration.is_newer_version("1.99.99", ee_changes.old_version)
+    not ee_changes
+    or not ee_changes.old_version
+    or flib_migration.is_newer_version("1.99.99", ee_changes.old_version)
   then
     return
   end

--- a/types.lua
+++ b/types.lua
@@ -1,4 +1,4 @@
 --- @meta
 
---- @alias BuiltEvent EventData.on_built_entity|EventData.on_robot_built_entity|EventData.on_entity_cloned|EventData.script_raised_built|EventData.script_raised_revive
---- @alias DestroyedEvent EventData.on_player_mined_entity|EventData.on_robot_mined_entity|EventData.on_entity_died|EventData.script_raised_destroy
+--- @alias BuiltEvent EventData.on_built_entity|EventData.on_robot_built_entity|EventData.on_space_platform_built_entity|EventData.on_entity_cloned|EventData.script_raised_built|EventData.script_raised_revive
+--- @alias DestroyedEvent EventData.on_player_mined_entity|EventData.on_robot_mined_entity|EventData.on_space_platform_mined_entity|EventData.on_entity_died|EventData.script_raised_destroy


### PR DESCRIPTION
Fix calling events for entities being built and mined on space platforms

on_built_events will still work if entity ghosts are considered but the actual creation is triggered by 'on_space_platform_built_entity'

White space changes due to opinionated formatter